### PR TITLE
Conditionally strip Linux dependencies

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,9 +29,9 @@ let package = Package(
         .target(
             name: "KippleNetworking",
             dependencies: [
-                .product(name: "AsyncHTTPClient", package: "async-http-client"),
-                .product(name: "NIOConcurrencyHelpers", package: "swift-nio"),
-                .product(name: "NIOHTTPCompression", package: "swift-nio-extras"),
+                .product(name: "AsyncHTTPClient", package: "async-http-client", condition: .when(platforms: [.linux])),
+                .product(name: "NIOConcurrencyHelpers", package: "swift-nio", condition: .when(platforms: [.linux])),
+                .product(name: "NIOHTTPCompression", package: "swift-nio-extras", condition: .when(platforms: [.linux])),
             ],
             swiftSettings: [
                 .define("DEBUG", .when(configuration: .debug)),

--- a/Package.swift
+++ b/Package.swift
@@ -2,6 +2,22 @@
 
 import PackageDescription
 
+#if os(Linux)
+let packageDependencies: [Package.Dependency] = [
+    .package(url: "https://github.com/apple/swift-nio", from: "2.41.1"),
+    .package(url: "https://github.com/apple/swift-nio-extras", from: "1.13.0"),
+    .package(url: "https://github.com/swift-server/async-http-client", from: "1.11.5"),
+]
+let productDependencies: [Target.Dependency] = [
+    .product(name: "AsyncHTTPClient", package: "async-http-client", condition: .when(platforms: [.linux])),
+    .product(name: "NIOConcurrencyHelpers", package: "swift-nio", condition: .when(platforms: [.linux])),
+    .product(name: "NIOHTTPCompression", package: "swift-nio-extras", condition: .when(platforms: [.linux])),
+]
+#else
+let packageDependencies: [Package.Dependency] = []
+let productDependencies: [Target.Dependency] = []
+#endif
+
 let package = Package(
     name: "KippleNetworking",
     platforms: [
@@ -14,10 +30,8 @@ let package = Package(
         .library(name: "KippleCodable", targets: ["KippleCodable"]),
         .library(name: "KippleNetworking", targets: ["KippleNetworking"]),
     ],
-    dependencies: [
-        .package(url: "https://github.com/apple/swift-nio", from: "2.41.1"),
-        .package(url: "https://github.com/apple/swift-nio-extras", from: "1.13.0"),
-        .package(url: "https://github.com/swift-server/async-http-client", from: "1.11.5"),
+    dependencies: packageDependencies + [
+        .package(url: "https://github.com/apple/swift-log", from: "1.5.2"),
         .package(url: "https://github.com/swift-kipple/Tools", from: "0.3.0"),
     ],
     targets: [
@@ -28,10 +42,8 @@ let package = Package(
         ),
         .target(
             name: "KippleNetworking",
-            dependencies: [
-                .product(name: "AsyncHTTPClient", package: "async-http-client", condition: .when(platforms: [.linux])),
-                .product(name: "NIOConcurrencyHelpers", package: "swift-nio", condition: .when(platforms: [.linux])),
-                .product(name: "NIOHTTPCompression", package: "swift-nio-extras", condition: .when(platforms: [.linux])),
+            dependencies: productDependencies + [
+                .product(name: "Logging", package: "swift-log"),
             ],
             swiftSettings: [
                 .define("DEBUG", .when(configuration: .debug)),

--- a/Sources/KippleNetworking/Foundation/Extensions/Request+AsURLRequest.swift
+++ b/Sources/KippleNetworking/Foundation/Extensions/Request+AsURLRequest.swift
@@ -21,6 +21,7 @@ extension Request {
             url: url,
             method: .init(rawValue: self.method.rawValue) ?? .get,
             parameters: parameters,
+            body: self.body,
             headers: headers,
             encoding: self.encoding
         )

--- a/Sources/KippleNetworking/Foundation/Extensions/URLRequest+Init.swift
+++ b/Sources/KippleNetworking/Foundation/Extensions/URLRequest+Init.swift
@@ -1,4 +1,4 @@
-// Copyright © 2022 Brian Drelling. All rights reserved.
+// Copyright © 2023 Brian Drelling. All rights reserved.
 
 #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 
@@ -9,6 +9,7 @@ public extension URLRequest {
     /// - Parameter url: The URL for the request. Accepts a URL or a String.
     /// - Parameter method: The HTTP method for the request. Defaults to `GET`.
     /// - Parameter parameters: The parameters to be converted into a String-keyed dictionary to send in the query string or HTTP body.
+    /// - Parameter body: The raw data to be set as the HTTP body of the request. If this value is not nil, then `encoding` must _not_ be `.httpBody`.
     /// - Parameter headers: The HTTP headers to send with the request.
     /// - Parameter encoding: The parameter encoding method. If nil, uses the default encoding for the provided HTTP method.
     /// - Returns: The configured `URLRequest` object.
@@ -16,9 +17,14 @@ public extension URLRequest {
         url: URLConvertible,
         method: HTTPMethod = .get,
         parameters: ParameterDictionaryConvertible? = nil,
+        body: Data? = nil,
         headers: [String: String] = [:],
         encoding: ParameterEncoding? = nil
     ) throws {
+        if case .httpBody = encoding, body?.isEmpty != false {
+            throw NetworkingError.httpBodyConflictsWithParameterEncoding
+        }
+
         let url = try url.asURL()
         self.init(url: url)
 
@@ -28,12 +34,15 @@ public extension URLRequest {
 
         // Parameters must be set after setting headers, because encoding dictates (and therefore overrides) the Content-Type header
         self.setParameters(parameters, method: method, encoding: encoding)
+
+        self.httpBody = body
     }
 
     init(
         url: URLConvertible,
         method: HTTPMethod = .get,
         parameters: ParameterDictionaryConvertible? = nil,
+        body: Data? = nil,
         headers: [HTTPHeader: String],
         encoding: ParameterEncoding? = nil
     ) throws {
@@ -41,6 +50,7 @@ public extension URLRequest {
             url: url,
             method: method,
             parameters: parameters,
+            body: body,
             headers: headers.asHeaderDictionary(),
             encoding: encoding
         )

--- a/Sources/KippleNetworking/Shared/Errors/NetworkingError.swift
+++ b/Sources/KippleNetworking/Shared/Errors/NetworkingError.swift
@@ -1,8 +1,9 @@
-// Copyright © 2022 Brian Drelling. All rights reserved.
+// Copyright © 2023 Brian Drelling. All rights reserved.
 
 import Foundation
 
 public enum NetworkingError: Error {
+    case httpBodyConflictsWithParameterEncoding
     case invalidContentType(String)
     case invalidHTTPHeader(String)
     case invalidStatusCode(HTTPStatusCode)
@@ -15,6 +16,8 @@ public enum NetworkingError: Error {
 extension NetworkingError: LocalizedError {
     public var errorDescription: String? {
         switch self {
+        case .httpBodyConflictsWithParameterEncoding:
+            return "Unable to set both data and parameters as HTTP body."
         case let .invalidContentType(contentType):
             return "Invalid content type '\(contentType)'."
         case let .invalidHTTPHeader(rawValue):

--- a/Sources/KippleNetworking/Shared/Models/Request.swift
+++ b/Sources/KippleNetworking/Shared/Models/Request.swift
@@ -7,6 +7,7 @@ public protocol Request {
     var path: String { get }
     var method: HTTPMethod { get }
     var parameters: [String: Any] { get }
+    var body: Data? { get }
     var headers: [String: String] { get }
     var encoding: ParameterEncoding { get }
     var rootResponseKey: String? { get }
@@ -25,6 +26,10 @@ public extension Request {
 
     var parameters: [String: Any] {
         [:]
+    }
+
+    var body: Data? {
+        nil
     }
 
     var headers: [String: String] {
@@ -49,6 +54,7 @@ public struct HTTPRequest: Request {
     public let path: String
     public let method: HTTPMethod
     public let parameters: [String: Any]
+    public let body: Data?
     public let headers: [String: String]
     public let encoding: ParameterEncoding
 
@@ -57,6 +63,7 @@ public struct HTTPRequest: Request {
         baseURL: String? = nil,
         method: HTTPMethod = .get,
         parameters: [String: Any] = [:],
+        body: Data? = nil,
         headers: [String: String] = [:],
         encoding: ParameterEncoding? = nil
     ) {
@@ -64,6 +71,7 @@ public struct HTTPRequest: Request {
         self.baseURL = baseURL
         self.method = method
         self.parameters = parameters
+        self.body = body
         self.headers = headers
         self.encoding = encoding ?? .defaultEncoding(for: method)
     }
@@ -91,9 +99,10 @@ public extension HTTPRequest {
         url: String,
         method: HTTPMethod = .get,
         parameters: [String: Any] = [:],
+        body: Data? = nil,
         headers: [String: String] = [:],
         encoding: ParameterEncoding? = nil
     ) {
-        self.init(path: "", baseURL: url, method: method, parameters: parameters, headers: headers, encoding: encoding)
+        self.init(path: "", baseURL: url, method: method, parameters: parameters, body: body, headers: headers, encoding: encoding)
     }
 }


### PR DESCRIPTION
There are just too many dependencies being pulled in such that I get constant errors around stuff like:

```
<unknown>:0: error: missing required module '_AtomicsShims'
```

Going to attempt to remove these on macOS since they are entirely unnecessary. So long as it doesn't impact downstream dependencies, it should be perfect.